### PR TITLE
add transaction serialization

### DIFF
--- a/src/sum-tree/merkle-tree-node.js
+++ b/src/sum-tree/merkle-tree-node.js
@@ -1,9 +1,9 @@
-const utils = require('../utils')
+BN = require('web3').utils.BN
 
 class MerkleTreeNode {
   constructor (data, sum) {
-    this.data = data + utils.int32ToHex(sum)
-    this.sum = sum
+    this.sum = new BN(sum)
+    this.data = data + this.sum.toString(16,2 * 16) // 2*bytes = num chars in hex 
   }
 }
 

--- a/src/sum-tree/merkle-tree-node.js
+++ b/src/sum-tree/merkle-tree-node.js
@@ -3,7 +3,7 @@ BN = require('web3').utils.BN
 class MerkleTreeNode {
   constructor (data, sum) {
     this.sum = new BN(sum)
-    this.data = data + this.sum.toString(16,2 * 16) // 2*bytes = num chars in hex 
+    this.data = data.slice(2) + this.sum.toString(16,2 * 16) // 2*bytes = num chars in hex 
   }
 }
 

--- a/src/sum-tree/plasma-sum-tree.js
+++ b/src/sum-tree/plasma-sum-tree.js
@@ -1,31 +1,36 @@
 const MerkleSumTree = require('./sum-tree')
 const MerkleTreeNode = require('./merkle-tree-node')
-const BN = require('web3').utils
+const BN = require('web3').utils.BN
 
 class PlasmaMerkleSumTree extends MerkleSumTree {
   parseLeaves (leaves) {
-    let bottom = []
     for (let i = 0; i < leaves.length - 1; i++) {
       let leaf = leaves[i]
       let nextLeaf = leaves[i+1]
       let enc = leaf.encode();
-      bottom[i].TXData = '0x' + new BN(enc).toString(16, 2 * enc.length)
+      leaves[i].TXData = '0x' + new BN(enc).toString(16, 2 * enc.length)
       let thisTR = leaf.transferRecords.elements[leaf.TRIndex]
       let nextTR = nextLeaf.transferRecords.elements[nextLeaf.TRIndex]
-      bottom[i].range = nextTR.start.sub(thisTR.start) // covers from the start of this tx to the start of the next, making an implicit notx in between
+      let typeDiff = nextTR.type.sub(thisTR.type)
+      let rangeDiff = (i === 0) ? nextTR.start : nextTR.start.sub(thisTR.start) // first one always starts at 0 in terms of proofs even if the first TR start isn't 0
+      let coverage = typeDiff.toString(16, 8) + rangeDiff.toString(16, 24)
+      leaves[i].range =  new BN(coverage, 16)// covers from the start of this tx to the start of the next, making an implicit notx in between
     }
     if (leaves.length === 1) { // weird edge case with only 1 TX in block --> covers 0 to end --> range = end+1
-      bottom[0].range = bottom[0].transferRecords.elements[0].end.add(new BN(1))
-    } else { // otherwise there's more than one tx and we set the first and last ranges as follows
-      bottom[0].range = leaves[1].transferRecords.elements[leaves[1].TRIndex] // first covers from 0 to second transaction's start
-      let lastLeaf = leaves[leaves.length-1]
+      let typeDiff = leaves[0].transferRecords.elements[0].type
+      let rangeDiff = leaves[0].transferRecords.elements[0].end.add(new BN(1))
+      debugger
+      let coverage = typeDiff.toString(16, 8) + rangeDiff.toString(16, 24)
+      leaves[0].range = new BN(coverage, 16)
+    } else { // otherwise there's more than one tx and we set the last range as follows
+      let lastLeaf = leaves[leaves.length-1] // set encoding data of last leaf since we missed it above
       let enc = lastLeaf.encode();
-      bottom[leaves.length-1].TXData = '0x' + new BN(enc).toString(16, 2 * enc.length)
+      leaves[leaves.length-1].TXData = '0x' + new BN(enc).toString(16, 2 * enc.length)  
       let lastTR = lastLeaf.transferRecords.elements[lastLeaf.TRIndex]
-      bottom[leaves.length-1].range = lastTR.end.sub(lastTR.start).add(new BN(1))
+      leaves[leaves.length-1].range = lastTR.end.sub(lastTR.start).add(new BN(1))
     }
-    return bottom.map((bot) => {
-      return new MerkleTreeNode(this.hash(bot.TXData), bot.range)
+    return leaves.map((leaf) => {
+      return new MerkleTreeNode(this.hash(leaf.TXData), leaf.range)
     })
   }
 }

--- a/src/sum-tree/plasma-sum-tree.js
+++ b/src/sum-tree/plasma-sum-tree.js
@@ -4,33 +4,37 @@ const BN = require('web3').utils.BN
 
 class PlasmaMerkleSumTree extends MerkleSumTree {
   parseLeaves (leaves) {
+    leaves = leaves.map((leaf) => {
+      let enc = leaf.encode()
+      let TR = leaf.transferRecords.elements[leaf.TRIndex]
+      return {
+        data: this.hash('0x' + new BN(enc).toString(16, 2 * enc.length)),
+        typedStart: TR.type.toString(16, 8) + TR.start.toString(16, 24),
+        typedEnd: TR.type.toString(16, 8) + TR.end.toString(16, 24)
+      }
+    })
+    leaves[0].start = 0 // start of the leaf's coverage is 0 to the sum tree, even if TR is not
+    leaves.push({typedStart: new BN('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF',16)}) // add a fake final TR which happens at the final coinpost
     for (let i = 0; i < leaves.length - 1; i++) {
-      let leaf = leaves[i]
-      let nextLeaf = leaves[i+1]
-      let enc = leaf.encode();
-      leaves[i].TXData = '0x' + new BN(enc).toString(16, 2 * enc.length)
-      let thisTR = leaf.transferRecords.elements[leaf.TRIndex]
-      let nextTR = nextLeaf.transferRecords.elements[nextLeaf.TRIndex]
-      let typeDiff = nextTR.type.sub(thisTR.type)
-      let rangeDiff = (i === 0) ? nextTR.start : nextTR.start.sub(thisTR.start) // first one always starts at 0 in terms of proofs even if the first TR start isn't 0
-      let coverage = typeDiff.toString(16, 8) + rangeDiff.toString(16, 24)
-      leaves[i].range =  new BN(coverage, 16)// covers from the start of this tx to the start of the next, making an implicit notx in between
-    }
-    if (leaves.length === 1) { // weird edge case with only 1 TX in block --> covers 0 to end --> range = end+1
-      let typeDiff = leaves[0].transferRecords.elements[0].type
-      let rangeDiff = leaves[0].transferRecords.elements[0].end.add(new BN(1))
-      debugger
-      let coverage = typeDiff.toString(16, 8) + rangeDiff.toString(16, 24)
-      leaves[0].range = new BN(coverage, 16)
-    } else { // otherwise there's more than one tx and we set the last range as follows
-      let lastLeaf = leaves[leaves.length-1] // set encoding data of last leaf since we missed it above
-      let enc = lastLeaf.encode();
-      leaves[leaves.length-1].TXData = '0x' + new BN(enc).toString(16, 2 * enc.length)  
-      let lastTR = lastLeaf.transferRecords.elements[lastLeaf.TRIndex]
-      leaves[leaves.length-1].range = lastTR.end.sub(lastTR.start).add(new BN(1))
+      leaves[i].range = leaves[i+1].typedStart.sub(leaves[i].typedStart)
     }
     return leaves.map((leaf) => {
-      return new MerkleTreeNode(this.hash(leaf.TXData), leaf.range)
+      return new MerkleTreeNode(leaf.data, leaf.range)
+    })
+  }
+
+  getBranch(leafIndex) {
+    if (leafIndex >= this.levels[0].length || leafIndex < 0) {throw new Error('invalid branch index requested')}
+    // let path = new BN(leafIndex).toString(2, this.levels.length-1)
+    let proof = []
+    let nodeIndex = Math.floor((leafIndex + 1) / 2) * 2
+    for (let i = 0; i < this.levels.length; i++) {
+      proof.push(this.levels[i][nodeIndex])
+      proof.push(this.levels[i][nodeIndex+1])
+      nodeIndex = Math.floor(nodeIndex / 2)
+    }
+    return proof.map((node) => {
+      return (node === undefined) ? this.emptyLeaf() : node
     })
   }
 }

--- a/src/sum-tree/plasma-sum-tree.js
+++ b/src/sum-tree/plasma-sum-tree.js
@@ -1,33 +1,32 @@
 const MerkleSumTree = require('./sum-tree')
 const MerkleTreeNode = require('./merkle-tree-node')
-
-class PlasmaMerkleTreeNode {
-  constructor (data, start, offset) {
-    this.data = data
-    this.start = start
-    this.offset = offset
-    this.sum = start + offset
-  }
-
-  isEmptyNode () {
-    return this.start === 0 && this.offset === 0
-  }
-}
+const BN = require('web3').utils
 
 class PlasmaMerkleSumTree extends MerkleSumTree {
-  emptyLeaf () {
-    return new PlasmaMerkleTreeNode(0, 0, 0)
-  }
-
   parseLeaves (leaves) {
-    return leaves.map((leaf) => {
-      return new PlasmaMerkleTreeNode(this.hash(leaf.data), leaf.start, leaf.offset)
+    let bottom = []
+    for (let i = 0; i < leaves.length - 1; i++) {
+      let leaf = leaves[i]
+      let nextLeaf = leaves[i+1]
+      let enc = leaf.encode();
+      bottom[i].TXData = '0x' + new BN(enc).toString(16, 2 * enc.length)
+      let thisTR = leaf.transferRecords.elements[leaf.TRIndex]
+      let nextTR = nextLeaf.transferRecords.elements[nextLeaf.TRIndex]
+      bottom[i].range = nextTR.start.sub(thisTR.start) // covers from the start of this tx to the start of the next, making an implicit notx in between
+    }
+    if (leaves.length === 1) { // weird edge case with only 1 TX in block --> covers 0 to end --> range = end+1
+      bottom[0].range = bottom[0].transferRecords.elements[0].end.add(new BN(1))
+    } else { // otherwise there's more than one tx and we set the first and last ranges as follows
+      bottom[0].range = leaves[1].transferRecords.elements[leaves[1].TRIndex] // first covers from 0 to second transaction's start
+      let lastLeaf = leaves[leaves.length-1]
+      let enc = lastLeaf.encode();
+      bottom[leaves.length-1].TXData = '0x' + new BN(enc).toString(16, 2 * enc.length)
+      let lastTR = lastLeaf.transferRecords.elements[lastLeaf.TRIndex]
+      bottom[leaves.length-1].range = lastTR.end.sub(lastTR.start).add(new BN(1))
+    }
+    return bottom.map((bot) => {
+      return new MerkleTreeNode(this.hash(bot.TXData), bot.range)
     })
-  }
-
-  leafParent (left, right) {
-    let sum = (right.isEmptyNode()) ? (left.sum) : (right.sum - left.start)
-    return new MerkleTreeNode(this.hash(left.data + right.data), sum)
   }
 }
 

--- a/src/sum-tree/plasma-sum-tree.js
+++ b/src/sum-tree/plasma-sum-tree.js
@@ -13,8 +13,8 @@ class PlasmaMerkleSumTree extends MerkleSumTree {
         encoding: '0x' + new BN(enc).toString(16, 2 * enc.length)
       }
     })
-    leaves[0].start = 0 // start of the leaf's coverage is 0 to the sum tree, even if TR is not
-    leaves.push({typedStart: new BN('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF',16)}) // add a fake final TR which happens at the final coinpost
+    leaves[0].typedStart = new BN(0) // start of the leaf's coverage is 0 to the sum tree, even if TR is not
+    leaves.push({typedStart: new BN('ffffffffffffffffffffffffffffffff',16)}) // add a fake final TR which happens at the final coinpost
     let parsed = []
     for (let i = 0; i < leaves.length - 1; i++) {
       let range = leaves[i+1].typedStart.sub(leaves[i].typedStart)
@@ -23,12 +23,11 @@ class PlasmaMerkleSumTree extends MerkleSumTree {
     return parsed
   }
 
-  getBranch(leafIndex) {
+  getBranch(leafIndex) { // returns an array of nodes which can be use to verify the merkle branch
     if (leafIndex >= this.levels[0].length || leafIndex < 0) {throw new Error('invalid branch index requested')}
     let proof = []
     let nodeIndex = Math.floor(leafIndex / 2) * 2
     for (let i = 0; i < this.levels.length; i++) {
-      debugger
       proof.push(this.levels[i][nodeIndex])
       proof.push(this.levels[i][nodeIndex+1])
       nodeIndex = Math.floor(nodeIndex / 4) * 2

--- a/src/sum-tree/plasma-sum-tree.js
+++ b/src/sum-tree/plasma-sum-tree.js
@@ -19,19 +19,19 @@ class PlasmaMerkleSumTree extends MerkleSumTree {
       leaves[i].range = leaves[i+1].typedStart.sub(leaves[i].typedStart)
     }
     return leaves.map((leaf) => {
-      return new MerkleTreeNode(leaf.data, leaf.range)
+      return new MerkleTreeNode(this.hash(leaf.TXData), leaf.range)
     })
   }
 
   getBranch(leafIndex) {
     if (leafIndex >= this.levels[0].length || leafIndex < 0) {throw new Error('invalid branch index requested')}
-    // let path = new BN(leafIndex).toString(2, this.levels.length-1)
     let proof = []
-    let nodeIndex = Math.floor((leafIndex + 1) / 2) * 2
+    let nodeIndex = Math.floor(leafIndex / 2) * 2
     for (let i = 0; i < this.levels.length; i++) {
+      debugger
       proof.push(this.levels[i][nodeIndex])
       proof.push(this.levels[i][nodeIndex+1])
-      nodeIndex = Math.floor(nodeIndex / 2)
+      nodeIndex = Math.floor(nodeIndex / 4) * 2
     }
     return proof.map((node) => {
       return (node === undefined) ? this.emptyLeaf() : node

--- a/src/sum-tree/sum-tree.js
+++ b/src/sum-tree/sum-tree.js
@@ -6,9 +6,9 @@ class MerkleSumTree {
     if (!leaves) {
       leaves = []
     }
-
-    leaves = this.parseLeaves(leaves)
-    this.levels = this.generate(leaves, [leaves])
+    this.leaves = leaves
+    let bottom = this.parseLeaves(leaves)
+    this.levels = this.generate(bottom, [bottom])
   }
 
   root () {
@@ -30,7 +30,7 @@ class MerkleSumTree {
   }
 
   parent (left, right) {
-    return new MerkleTreeNode(this.hash(left.data + right.data), (left.sum.add(right.sum)))
+    return new MerkleTreeNode(this.hash('0x' + left.data + right.data), (left.sum.add(right.sum)))
   }
 
   generate (children, levels) {

--- a/src/sum-tree/sum-tree.js
+++ b/src/sum-tree/sum-tree.js
@@ -26,7 +26,7 @@ class MerkleSumTree {
   }
 
   emptyLeaf () {
-    return new MerkleTreeNode(0, 0)
+    return new MerkleTreeNode('0000000000000000000000000000000000000000000000000000000000000000', 0)
   }
 
   parent (left, right) {

--- a/src/sum-tree/sum-tree.js
+++ b/src/sum-tree/sum-tree.js
@@ -28,7 +28,6 @@ class MerkleSumTree {
   }
 
   emptyLeaf () {
-    debugger
     return new MerkleTreeNode('0x0000000000000000000000000000000000000000000000000000000000000000', 0)
   }
 
@@ -46,7 +45,6 @@ class MerkleSumTree {
       let left = children[i]
       let right = (i + 1 === children.length) ? this.emptyLeaf() : children[i + 1]
       let parent = this.parent(left, right)
-      debugger
       parents.push(parent)
     }
 

--- a/src/sum-tree/sum-tree.js
+++ b/src/sum-tree/sum-tree.js
@@ -28,7 +28,8 @@ class MerkleSumTree {
   }
 
   emptyLeaf () {
-    return new MerkleTreeNode('0000000000000000000000000000000000000000000000000000000000000000', 0)
+    debugger
+    return new MerkleTreeNode('0x0000000000000000000000000000000000000000000000000000000000000000', 0)
   }
 
   parent (left, right) {
@@ -45,6 +46,7 @@ class MerkleSumTree {
       let left = children[i]
       let right = (i + 1 === children.length) ? this.emptyLeaf() : children[i + 1]
       let parent = this.parent(left, right)
+      debugger
       parents.push(parent)
     }
 

--- a/src/sum-tree/sum-tree.js
+++ b/src/sum-tree/sum-tree.js
@@ -16,7 +16,7 @@ class MerkleSumTree {
   }
 
   hash (value) {
-    return web3.utils.sha3(value).slice(2)
+    return web3.utils.soliditySha3(value)
   }
 
   parseLeaves (leaves) {
@@ -29,12 +29,8 @@ class MerkleSumTree {
     return new MerkleTreeNode(0, 0)
   }
 
-  innerParent (left, right) {
-    return new MerkleTreeNode(this.hash(left.data + right.data), (left.sum + right.sum))
-  }
-
-  leafParent (left, right) {
-    return this.innerParent(left, right)
+  parent (left, right) {
+    return new MerkleTreeNode(this.hash(left.data + right.data), (left.sum.add(right.sum)))
   }
 
   generate (children, levels) {
@@ -46,7 +42,7 @@ class MerkleSumTree {
     for (let i = 0; i < children.length; i += 2) {
       let left = children[i]
       let right = (i + 1 === children.length) ? this.emptyLeaf() : children[i + 1]
-      let parent = (levels.length === 1) ? this.leafParent(left, right) : this.innerParent(left, right)
+      let parent = this.parent(left, right)
       parents.push(parent)
     }
 

--- a/src/sum-tree/sum-tree.js
+++ b/src/sum-tree/sum-tree.js
@@ -4,11 +4,13 @@ const MerkleTreeNode = require('./merkle-tree-node')
 class MerkleSumTree {
   constructor (leaves) {
     if (!leaves) {
-      leaves = []
+      this.leaves = []
+      this.levels = this.generate([], [[]])
+    } else {
+      this.leaves = leaves
+      let bottom = this.parseLeaves(leaves)
+      this.levels = this.generate(bottom, [bottom])
     }
-    this.leaves = leaves
-    let bottom = this.parseLeaves(leaves)
-    this.levels = this.generate(bottom, [bottom])
   }
 
   root () {

--- a/src/transaction-serialization.js
+++ b/src/transaction-serialization.js
@@ -1,26 +1,24 @@
-const Web3 = require('web3')
-const BN = Web3.utils.BN
-
-const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'))
+const web3 = require('web3')
+const BN = web3.utils.BN
 
 const isSerializableList = function (potentialList) {
   return potentialList instanceof SimpleSerializableList
 }
 
 const isSignatureList = function (potentialSigList) {
-  var isList = isSerializableList(potentialSigList)
-  var areSignatures = potentialSigList.elements_type === 'Signature'
+  const isList = isSerializableList(potentialSigList)
+  const areSignatures = potentialSigList.elementsType === 'Signature'
   return isList && areSignatures
 }
 
 const isTransferList = function (potentialTransferList) {
-  var isList = isSerializableList(potentialTransferList)
-  var areTransfers = potentialTransferList.elements_type === 'TransferRecord'
+  const isList = isSerializableList(potentialTransferList)
+  const areTransfers = potentialTransferList.elementsType === 'TransferRecord'
   return isList && areTransfers
 }
 
 const getFieldBytes = function (field) { // TODO ADD THE RECURSIVE SERZN
-  var typeChecker = field[1]
+  const typeChecker = field[1]
   if (typeChecker === web3.utils.isAddress) {
     return 20
   } else {
@@ -29,8 +27,8 @@ const getFieldBytes = function (field) { // TODO ADD THE RECURSIVE SERZN
 }
 
 const getfieldsTotalBytes = function (fields) {
-  var numBytes = 0
-  for (var i = 0; i < fields.length; i++) {
+  let numBytes = 0
+  for (let i = 0; i < fields.length; i++) {
     numBytes += getFieldBytes(fields[i])
   }
   return numBytes
@@ -39,17 +37,17 @@ const getfieldsTotalBytes = function (fields) {
 // input: encoding of SimpleSerializableElement as byte array,
 //       element schema
 //
-// output: SimpleSerializableelement
+// output: SimpleSerializablEelement
 const decodeElement = function (encoding, schema) {
-  var decodedFields = []
-  var fields = schema.fields
-  console.assert(encoding.length === getfieldsTotalBytes(fields), 'whoops--the encoding is the wrong length for this schema')
-  var currentPos = 0
-  for (var i = 0; i < fields.length; i++) {
-    var field = fields[i]
-    var fieldTypeChecker = field[1]
-    var fieldBytesLen = getFieldBytes(field)
-    var byteSlice = encoding.slice(currentPos, currentPos + fieldBytesLen)
+  let decodedFields = []
+  const fields = schema.fields
+  if (encoding.length !== getfieldsTotalBytes(fields)) {throw new Error('whoops--the encoding is the wrong length for this schema')}
+  let currentPos = 0
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i]
+    const fieldTypeChecker = field[1]
+    const fieldBytesLen = getFieldBytes(field)
+    const byteSlice = encoding.slice(currentPos, currentPos + fieldBytesLen)
     if (fieldTypeChecker === web3.utils.isAddress) {
       decodedFields[i] = decodeAddress(byteSlice)
     } else {
@@ -65,13 +63,13 @@ const decodeElement = function (encoding, schema) {
 //
 // output: SimpleSerializableList
 const decodeList = function (encoding, schema) {
-  var numElements = encoding[0] // first byte is number of elements
-  var elementLen = new BN(encoding.slice(1, 4)).toNumber() // next three is their size
-  var elements = []
-  for (var i = 0; i < numElements; i++) {
-    var startPos = 4 + i * elementLen
-    var endPos = startPos + elementLen
-    var slice = encoding.slice(startPos, endPos)
+  const numElements = encoding[0] // first byte is number of elements
+  const elementLen = new BN(encoding.slice(1, 4)).toNumber() // next three is their size
+  let elements = []
+  for (let i = 0; i < numElements; i++) {
+    const startPos = 4 + i * elementLen
+    const endPos = startPos + elementLen
+    const slice = encoding.slice(startPos, endPos)
     elements[i] = decodeElement(slice, schema)
   }
   return new SimpleSerializableList(elements, schema)
@@ -85,31 +83,32 @@ class SimpleSerializableElement {
     this.elementType = schema.typeName
     this.fields = schema.fields
     this.numFields = this.fields.length
-    console.assert(this.numFields > 0, 'whoops--schema is empty')
-    console.assert(this.numFields === values.length, 'whoops--passed different sized array than number of fields in schema')
-    for (var i = 0; i < this.numFields; i++) {
-      var field = this.fields[i]
-      var typeChecker = field[1]
+    if (this.numFields === 0) {throw new Error('whoops--schema is empty')}
+    if (this.numFields !== values.length) {throw new Error('whoops--passed different sized array than number of fields in schema')}
+    for (let i = 0; i < this.numFields; i++) {
+      const field = this.fields[i]
+      const typeChecker = field[1]
+      let value
       if (typeChecker === web3.utils.isAddress) {
-        var value = values[i]
+        value = values[i]
       } else {
-        var value = new BN(values[i])
+        value = new BN(values[i])
       }
-      console.assert(field[1](value), 'whoops--type checker failed for the ' + i + 'th value')
+      if (!field[1](value)) {throw new Error('whoops--type checker failed for the ' + i + 'th value')}
       this[field[0]] = value
     }
   }
 
   encode () {
-    var encoding = []
-    for (var i = 0; i < this.fields.length; i++) {
-      var bytesToAdd = []
-      var field = this.fields[i]
-      var fieldName = field[0]
-      var fieldChecker = field[1]
-      var encodingFunction = field[2]
-      var fieldValue = this[fieldName]
-      console.assert(fieldChecker(fieldValue), 'whoops--type checker failed for the ' + i + 'th value')
+    let encoding = []
+    for (let i = 0; i < this.fields.length; i++) {
+      let bytesToAdd = []
+      const field = this.fields[i]
+      const fieldName = field[0]
+      const fieldChecker = field[1]
+      const encodingFunction = field[2]
+      const fieldValue = this[fieldName]
+      if(!fieldChecker(fieldValue)) {throw new Error('whoops--type checker failed for the ' + i + 'th value')}
       bytesToAdd = encodingFunction(fieldValue)
       encoding = encoding.concat(bytesToAdd)
     }
@@ -119,31 +118,30 @@ class SimpleSerializableElement {
 
 // A deserialized List.  Invoke with new SSL([values],schemas.schema)
 // Allows for encoding with .encode(), decode with decodeList(encoding,schemas.schema)
-// Check elements' type via element.elements_type property (returns string)
+// Check elements' type via element.elementsType property (returns string)
 class SimpleSerializableList {
   constructor (inputElements, schema) {
-    this.elements_type = schema.typeName
+    this.elementsType = schema.typeName
     this.numElements = inputElements.length
     this.elements = []
-    console.assert(inputElements[0] instanceof SimpleSerializableElement, 'whoops--the first element isn\'t a SimpleSerializableElement object')
-    for (var i = 0; i < this.numElements; i++) {
-      console.assert(
-        inputElements[i % this.numElements].fields ===
-        inputElements[(i + 1) % this.numElements].fields
-        , 'whoops--one of the elements in the array isn\'t a serializable object!') // make sure all same type
+    if (!(inputElements[0] instanceof SimpleSerializableElement)) {throw new Error('whoops--the first element isn\'t a SimpleSerializableElement object')}
+    for (let i = 0; i < this.numElements; i++) {
+      if (inputElements[i % this.numElements].fields !== inputElements[(i + 1) % this.numElements].fields) {
+        throw new Error('whoops--one of the elements in the array isn\'t a serializable object!')
+      } // ^ make sure all same type
       this.elements[i] = inputElements[i]
     }
   }
 
   encode () {
-    var encoding = []
+    let encoding = []
     encoding[0] = new BN(this.numElements).toArray('be', 1)[0]
-    var numBytesPerElement = new BN(
+    const numBytesPerElement = new BN(
       getfieldsTotalBytes(this.elements[0].fields)
     )
     encoding = encoding.concat(numBytesPerElement.toArray('be', 3))
-    for (var i = 0; i < this.numElements; i++) {
-      var elementEncoding = this.elements[i].encode()
+    for (let i = 0; i < this.numElements; i++) {
+      const elementEncoding = this.elements[i].encode()
       encoding = encoding.concat(elementEncoding)
     }
     return encoding
@@ -152,7 +150,7 @@ class SimpleSerializableList {
 
 const isIntExpressibleInBytes = function (numBytes) {
   return function (i) {
-    var b = new BN(i).toArray()
+    const b = new BN(i).toArray()
     if (b.length <= numBytes) {
       return numBytes
     } else {
@@ -163,24 +161,19 @@ const isIntExpressibleInBytes = function (numBytes) {
 
 const intToNBytes = function (numBytes) {
   return function (numToEncode) {
-    var array = numToEncode.toArray('be', numBytes)
-    return array
+    return numToEncode.toArray('be', numBytes)
   }
 }
 
 const encodeAddress = function (address) {
-  var without0x = address.substring(2) // remove '0x' from string
-  var array = new BN(without0x, 16).toArray('be', 20) // decode hex string to 20-long big endian array
-  return array
+  const without0x = address.substring(2) // remove '0x' from string
+  return new BN(without0x, 16).toArray('be', 20) // decode hex string to 20-long big endian array
+  
 }
 
 const decodeAddress = function (encodedAddr) {
-  var asBN = new BN(encodedAddr, 'be')
+  const asBN = new BN(encodedAddr, 'be')
   return '0x' + asBN.toString(16, 40) // 40-long hex string
-};
-
-const selfEncode = function (element) {
-  return element.encode()
 }
 
 // This is the schemas object which allows us
@@ -192,7 +185,7 @@ const selfEncode = function (element) {
 //     ]
 // }}]
 // !!!!NOTE!!!! -- we must pass byte arrays instead of JS numbers if the number exceeds 2^53
-var schemas = {
+let schemas = {
   TransferRecord: {
     typeName: 'TransferRecord',
     fields: [
@@ -200,7 +193,7 @@ var schemas = {
       ['recipient', web3.utils.isAddress, encodeAddress],
       ['type', isIntExpressibleInBytes(4), intToNBytes(4)],
       ['start', isIntExpressibleInBytes(12), intToNBytes(12)],
-      ['offset', isIntExpressibleInBytes(12), intToNBytes(12)],
+      ['end', isIntExpressibleInBytes(12), intToNBytes(12)],
       ['block', isIntExpressibleInBytes(32), intToNBytes(32)]
     ]
   },
@@ -214,13 +207,77 @@ var schemas = {
   }
 }
 
+class TR {
+  constructor(arg) {
+    if (arg.length === getfieldsTotalBytes(schemas.TransferRecord.fields)) { // it's an encoding
+      return decodeElement(arg, schemas.TransferRecord)
+    } else if (arg instanceof SimpleSerializableElement) { // already a TR
+      return arg
+    } else if (arg instanceof Array) { // ordered array of elements
+      return new SimpleSerializableElement(arg, schemas.TransferRecord)
+    } else {
+      return new SimpleSerializableElement([
+        arg.sender, arg.recipient, arg.type, arg.start, arg.end, arg.block
+      ], schemas.TransferRecord)
+    }
+  }
+}
+
+class TRList {
+  constructor(TRs) {
+    if (isTransferList(TRs)) {
+      return TRs
+    } else if (TRs instanceof Array && typeof TRs[0] === 'number') {
+      return decodeList(TRs, schemas.TransferRecord)
+    } else if (!(TRs[0] instanceof SimpleSerializableElement)) {
+      TRs = TRs.map((transfer) => {
+        return new TR(transfer)
+      })
+    }
+    return new SimpleSerializableList(TRs, schemas.TransferRecord)
+  }
+}
+
+debugger
+
+class Sig {
+  constructor(arg) {
+  if (arg.length === getfieldsTotalBytes(schemas.Signature.fields)) { // it's an encoding
+      return decodeElement(arg, schemas.Signature)
+    } else if (arg instanceof SimpleSerializableElement) { // already a TR
+      return arg
+    } else if (arg instanceof Array) { // ordered array of elements
+      return new SimpleSerializableElement(arg, schemas.Signature)
+    } else {
+      return new SimpleSerializableElement([
+        arg.v, arg.r, arg.s
+      ], schemas.Signature)
+    }
+  }
+}
+
+class SigList {
+  constructor(sigs) {
+    if (isSignatureList(sigs)) {
+      return sigs
+    } else if (sigs instanceof Array && typeof sigs[0] === 'number') {
+      return decodeList(sigs, schemas.Signature)
+    } else if (!(sigs[0] instanceof SimpleSerializableElement)) {
+      sigs = sigs.map((sig) => {
+        return new Sig(sig)
+      })
+    }
+    return new SimpleSerializableList(sigs, schemas.Signature)
+  }
+}
+
 class Transaction {
-  constructor (TRList, sigList) {
-    console.assert(TRList.length === sigList.length, 'OOPS--passed a sig list and TR list of different lengths')
-    console.assert(isTransferList(TRList), 'OOPs -- you didn\'t pass a simpleserializablelist list of TRs')
-    console.assert(isSignatureList(sigList), 'OOPS -- you didn\'t pass a simpleserializablelist list of TRs')
-    this.transferRecords = TRList
-    this.signatures = sigList
+  constructor (TRs, sigs) {
+    if (typeof sigs === 'undefined') { // then it's just been passed an encoding
+      return decodeTransaction(TRs) // TRList is actually the encoding
+    }
+      this.transferRecords = new TRList(TRs)
+      this.signatures = new SigList(sigs)
   }
   encode () {
     return this.transferRecords.encode().concat(this.signatures.encode())
@@ -228,25 +285,31 @@ class Transaction {
 }
 
 const decodeTransaction = function (encoding) {
-  var numTRs = encoding[0]
-  var totalTRBytes = 4 + numTRs * getfieldsTotalBytes(schemas.TransferRecord.fields)
-  var numSigs = encoding[totalTRBytes] // first byte after the transactions
-  console.assert(numTRs === numSigs, 'oops-- badly formed transaction encoding :(')
-  var TRSlice = encoding.slice(0, totalTRBytes) // first totalTRBytes
-  var sigSlice = encoding.slice(totalTRBytes) // this gets the rest
-  var TRList = decodeList(TRSlice, schemas.TransferRecord)
-  var sigList = decodeList(sigSlice, schemas.Signature)
+  const numTRs = encoding[0]
+  const totalTRBytes = 4 + numTRs * getfieldsTotalBytes(schemas.TransferRecord.fields)
+  const numSigs = encoding[totalTRBytes] // first byte after the transactions
+  if (numTRs !== numSigs) {throw new Error('oops-- badly formed transaction encoding')}
+  const TRSlice = encoding.slice(0, totalTRBytes) // first totalTRBytes
+  const sigSlice = encoding.slice(totalTRBytes) // this gets the rest
+  const TRList = decodeList(TRSlice, schemas.TransferRecord)
+  const sigList = decodeList(sigSlice, schemas.Signature)
   return new Transaction(TRList, sigList)
 }
 
+debugger
+
 module.exports = {
-  schemas: schemas,
-  SimpleSerializableElement: SimpleSerializableElement,
-  SimpleSerializableList: SimpleSerializableList,
-  decodeElement: decodeElement,
-  decodeList: decodeList,
-  encodeAddress: encodeAddress,
-  decodeAddress: decodeAddress,
-  Transaction: Transaction,
-  decodeTransaction: decodeTransaction
+  schemas,
+  SimpleSerializableElement,
+  SimpleSerializableList,
+  decodeElement,
+  decodeList,
+  encodeAddress,
+  decodeAddress,
+  Transaction,
+  decodeTransaction,
+  TR,
+  Sig,
+  TRList,
+  SigList
 }

--- a/src/transaction-serialization.js
+++ b/src/transaction-serialization.js
@@ -1,0 +1,252 @@
+const Web3 = require('web3')
+const BN = Web3.utils.BN
+
+const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'))
+
+const isSerializableList = function (potentialList) {
+  return potentialList instanceof SimpleSerializableList
+}
+
+const isSignatureList = function (potentialSigList) {
+  var isList = isSerializableList(potentialSigList)
+  var areSignatures = potentialSigList.elements_type === 'Signature'
+  return isList && areSignatures
+}
+
+const isTransferList = function (potentialTransferList) {
+  var isList = isSerializableList(potentialTransferList)
+  var areTransfers = potentialTransferList.elements_type === 'TransferRecord'
+  return isList && areTransfers
+}
+
+const getFieldBytes = function (field) { // TODO ADD THE RECURSIVE SERZN
+  var typeChecker = field[1]
+  if (typeChecker === web3.utils.isAddress) {
+    return 20
+  } else {
+    return typeChecker(0) // type checker should always allow encoding 0 and when it does returns the number of bytes in encoding
+  }
+}
+
+const getfieldsTotalBytes = function (fields) {
+  var numBytes = 0
+  for (var i = 0; i < fields.length; i++) {
+    numBytes += getFieldBytes(fields[i])
+  }
+  return numBytes
+}
+
+// input: encoding of SimpleSerializableElement as byte array,
+//       element schema
+//
+// output: SimpleSerializableelement
+const decodeElement = function (encoding, schema) {
+  var decodedFields = []
+  var fields = schema.fields
+  console.assert(encoding.length === getfieldsTotalBytes(fields), 'whoops--the encoding is the wrong length for this schema')
+  var currentPos = 0
+  for (var i = 0; i < fields.length; i++) {
+    var field = fields[i]
+    var fieldTypeChecker = field[1]
+    var fieldBytesLen = getFieldBytes(field)
+    var byteSlice = encoding.slice(currentPos, currentPos + fieldBytesLen)
+    if (fieldTypeChecker === web3.utils.isAddress) {
+      decodedFields[i] = decodeAddress(byteSlice)
+    } else {
+      decodedFields[i] = new BN(byteSlice)
+    }
+    currentPos += fieldBytesLen
+  }
+  return new SimpleSerializableElement(decodedFields, schema);
+}
+
+// input: encoding of SimpleSerializableList as a byte array,
+//       elements' schema
+//
+// output: SimpleSerializableList
+const decodeList = function (encoding, schema) {
+  var numElements = encoding[0] // first byte is number of elements
+  var elementLen = new BN(encoding.slice(1, 4)).toNumber() // next three is their size
+  var elements = []
+  for (var i = 0; i < numElements; i++) {
+    var startPos = 4 + i * elementLen
+    var endPos = startPos + elementLen
+    var slice = encoding.slice(startPos, endPos)
+    elements[i] = decodeElement(slice, schema)
+  }
+  return new SimpleSerializableList(elements, schema)
+}
+
+// A deserialized object.  Invoke with new SSE([values],schemas.schema)
+// Allows for encoding with .encode(), decode with decodeElement(encoding,schemas.schema)
+// Check type via element.elementType property (returns string)
+class SimpleSerializableElement {
+  constructor (values, schema) {
+    this.elementType = schema.typeName
+    this.fields = schema.fields
+    this.numFields = this.fields.length
+    console.assert(this.numFields > 0, 'whoops--schema is empty')
+    console.assert(this.numFields === values.length, 'whoops--passed different sized array than number of fields in schema')
+    for (var i = 0; i < this.numFields; i++) {
+      var field = this.fields[i]
+      var typeChecker = field[1]
+      if (typeChecker === web3.utils.isAddress) {
+        var value = values[i]
+      } else {
+        var value = new BN(values[i])
+      }
+      console.assert(field[1](value), 'whoops--type checker failed for the ' + i + 'th value')
+      this[field[0]] = value
+    }
+  }
+
+  encode () {
+    var encoding = []
+    for (var i = 0; i < this.fields.length; i++) {
+      var bytesToAdd = []
+      var field = this.fields[i]
+      var fieldName = field[0]
+      var fieldChecker = field[1]
+      var encodingFunction = field[2]
+      var fieldValue = this[fieldName]
+      console.assert(fieldChecker(fieldValue), 'whoops--type checker failed for the ' + i + 'th value')
+      bytesToAdd = encodingFunction(fieldValue)
+      encoding = encoding.concat(bytesToAdd)
+    }
+    return encoding
+  }
+}
+
+// A deserialized List.  Invoke with new SSL([values],schemas.schema)
+// Allows for encoding with .encode(), decode with decodeList(encoding,schemas.schema)
+// Check elements' type via element.elements_type property (returns string)
+class SimpleSerializableList {
+  constructor (inputElements, schema) {
+    this.elements_type = schema.typeName
+    this.numElements = inputElements.length
+    this.elements = []
+    console.assert(inputElements[0] instanceof SimpleSerializableElement, 'whoops--the first element isn\'t a SimpleSerializableElement object')
+    for (var i = 0; i < this.numElements; i++) {
+      console.assert(
+        inputElements[i % this.numElements].fields ===
+        inputElements[(i + 1) % this.numElements].fields
+        , 'whoops--one of the elements in the array isn\'t a serializable object!') // make sure all same type
+      this.elements[i] = inputElements[i]
+    }
+  }
+
+  encode () {
+    var encoding = []
+    encoding[0] = new BN(this.numElements).toArray('be', 1)[0]
+    var numBytesPerElement = new BN(
+      getfieldsTotalBytes(this.elements[0].fields)
+    )
+    encoding = encoding.concat(numBytesPerElement.toArray('be', 3))
+    for (var i = 0; i < this.numElements; i++) {
+      var elementEncoding = this.elements[i].encode()
+      encoding = encoding.concat(elementEncoding)
+    }
+    return encoding
+  }
+}
+
+const isIntExpressibleInBytes = function (numBytes) {
+  return function (i) {
+    var b = new BN(i).toArray()
+    if (b.length <= numBytes) {
+      return numBytes
+    } else {
+      return false
+    }
+  }
+}
+
+const intToNBytes = function (numBytes) {
+  return function (numToEncode) {
+    var array = numToEncode.toArray('be', numBytes)
+    return array
+  }
+}
+
+const encodeAddress = function (address) {
+  var without0x = address.substring(2) // remove '0x' from string
+  var array = new BN(without0x, 16).toArray('be', 20) // decode hex string to 20-long big endian array
+  return array
+}
+
+const decodeAddress = function (encodedAddr) {
+  var asBN = new BN(encodedAddr, 'be')
+  return '0x' + asBN.toString(16, 40) // 40-long hex string
+};
+
+const selfEncode = function (element) {
+  return element.encode()
+}
+
+// This is the schemas object which allows us
+// to define new serializations, like so:
+// [{schema:{
+//     typeName:'name',
+//     fields:[
+//         ['field_name', type_checker_function, encodingFunction]
+//     ]
+// }}]
+// !!!!NOTE!!!! -- we must pass byte arrays instead of JS numbers if the number exceeds 2^53
+var schemas = {
+  TransferRecord: {
+    typeName: 'TransferRecord',
+    fields: [
+      ['sender', web3.utils.isAddress, encodeAddress],
+      ['recipient', web3.utils.isAddress, encodeAddress],
+      ['type', isIntExpressibleInBytes(4), intToNBytes(4)],
+      ['start', isIntExpressibleInBytes(12), intToNBytes(12)],
+      ['offset', isIntExpressibleInBytes(12), intToNBytes(12)],
+      ['block', isIntExpressibleInBytes(32), intToNBytes(32)]
+    ]
+  },
+  Signature: {
+    typeName: 'Signature',
+    fields: [
+      ['v', isIntExpressibleInBytes(32), intToNBytes(32)],
+      ['r', isIntExpressibleInBytes(32), intToNBytes(32)],
+      ['s', isIntExpressibleInBytes(32), intToNBytes(32)]
+    ]
+  }
+}
+
+class Transaction {
+  constructor (TRList, sigList) {
+    console.assert(TRList.length === sigList.length, 'OOPS--passed a sig list and TR list of different lengths')
+    console.assert(isTransferList(TRList), 'OOPs -- you didn\'t pass a simpleserializablelist list of TRs')
+    console.assert(isSignatureList(sigList), 'OOPS -- you didn\'t pass a simpleserializablelist list of TRs')
+    this.transferRecords = TRList
+    this.signatures = sigList
+  }
+  encode () {
+    return this.transferRecords.encode().concat(this.signatures.encode())
+  }
+}
+
+const decodeTransaction = function (encoding) {
+  var numTRs = encoding[0]
+  var totalTRBytes = 4 + numTRs * getfieldsTotalBytes(schemas.TransferRecord.fields)
+  var numSigs = encoding[totalTRBytes] // first byte after the transactions
+  console.assert(numTRs === numSigs, 'oops-- badly formed transaction encoding :(')
+  var TRSlice = encoding.slice(0, totalTRBytes) // first totalTRBytes
+  var sigSlice = encoding.slice(totalTRBytes) // this gets the rest
+  var TRList = decodeList(TRSlice, schemas.TransferRecord)
+  var sigList = decodeList(sigSlice, schemas.Signature)
+  return new Transaction(TRList, sigList)
+}
+
+module.exports = {
+  schemas: schemas,
+  SimpleSerializableElement: SimpleSerializableElement,
+  SimpleSerializableList: SimpleSerializableList,
+  decodeElement: decodeElement,
+  decodeList: decodeList,
+  encodeAddress: encodeAddress,
+  decodeAddress: decodeAddress,
+  Transaction: Transaction,
+  decodeTransaction: decodeTransaction
+}

--- a/src/transaction-serialization.js
+++ b/src/transaction-serialization.js
@@ -238,8 +238,6 @@ class TRList {
   }
 }
 
-debugger
-
 class Sig {
   constructor(arg) {
   if (arg.length === getfieldsTotalBytes(schemas.Signature.fields)) { // it's an encoding
@@ -295,8 +293,6 @@ const decodeTransaction = function (encoding) {
   const sigList = decodeList(sigSlice, schemas.Signature)
   return new Transaction(TRList, sigList)
 }
-
-debugger
 
 module.exports = {
   schemas,

--- a/src/transaction-serialization.js
+++ b/src/transaction-serialization.js
@@ -272,7 +272,7 @@ class SigList {
 class Transaction {
   constructor (TRs, sigs) {
     if (typeof sigs === 'undefined') { // then it's just been passed an encoding
-      return decodeTransaction(TRs) // TRList is actually the encoding
+      return decodeTransaction(TRs) // TRs is actually the encoding
     }
       this.transferRecords = new TRList(TRs)
       this.signatures = new SigList(sigs)

--- a/test/dummy-tx-utils.js
+++ b/test/dummy-tx-utils.js
@@ -1,0 +1,58 @@
+const TS = require('../src/transaction-serialization')
+const web3 = require('web3')
+const BN = web3.utils.BN
+
+const genRandomNByteBN = function (numBytes) { // returns an int not byte array
+  let arr = []
+  for (let i = 0; i < numBytes; i++) {
+    arr.push(Math.floor(Math.random() * (256)))
+  }
+  return new BN(arr)
+}
+
+const genRandomAddress = function () {
+  const addr = genRandomNByteBN(20)
+  return TS.decodeAddress(addr)
+}
+
+const genRandomSignature = function () {
+  const v = genRandomNByteBN(32)
+  const r = genRandomNByteBN(32)
+  const s = genRandomNByteBN(32)
+  return new TS.Sig([v, r, s])
+}
+
+const genSequentialTR = function (prevTR) {
+  const sender = genRandomAddress()
+  const recipient = genRandomAddress()
+  const start = prevTR.end.add(genRandomNByteBN(6))
+  const end = start.add(genRandomNByteBN(6)).add(new BN(1)) // add 1 in case 0 though lol never gonna happen
+  const block = 0
+  const type = 0
+  return new TS.TR([sender, recipient, type, start, end, block])
+}
+
+const genSequentialTransaction = function (prevTransaction) {
+  const TRList = new TS.TRList([genSequentialTR(prevTransaction.transferRecords.elements[0])])
+  return new TS.Transaction(TRList, [genRandomSignature()])
+}
+
+const genNSequentialTransactions = function(n) {
+  let TXList = []
+  TXList[0] = new TS.Transaction([
+    [
+      '0x43aadf3d5b44290385fe4193a1b13f15ef3a4fd5',
+      '0x43aadf3d5b44290385fe4193a1b13f15ef3a4fd5',
+      0, 0, 0, 0]
+    ], [genRandomSignature()])
+  TXList[0].TRIndex = 0
+  for (let i = 1; i < n; i++) {
+    TXList[i] = genSequentialTransaction(TXList[i - 1])
+    TXList[i].TRIndex = 0
+  }
+  return TXList
+}
+
+module.exports = {
+  genNSequentialTransactions
+}

--- a/test/dummy-tx-utils.js
+++ b/test/dummy-tx-utils.js
@@ -39,12 +39,8 @@ const genSequentialTransaction = function (prevTransaction) {
 
 const genNSequentialTransactions = function(n) {
   let TXList = []
-  TXList[0] = new TS.Transaction([
-    [
-      '0x43aadf3d5b44290385fe4193a1b13f15ef3a4fd5',
-      '0x43aadf3d5b44290385fe4193a1b13f15ef3a4fd5',
-      0, 0, 0, 0]
-    ], [genRandomSignature()])
+  //
+  TXList[0] = new TS.Transaction([['0x43aadf3d5b44290385fe4193a1b13f15ef3a4fd5', '0x43aadf3d5b44290385fe4193a1b13f15ef3a4fd5', 0, 0, 1, 0] ], [genRandomSignature()])
   TXList[0].TRIndex = 0
   for (let i = 1; i < n; i++) {
     TXList[i] = genSequentialTransaction(TXList[i - 1])

--- a/test/sum-tree/merkle-sum.js
+++ b/test/sum-tree/merkle-sum.js
@@ -49,7 +49,7 @@ describe('MerkleSumTree', function () {
       }
     ])
     const root = tree.root()
-    assert.strictEqual(root.data, '7c0beda9f03a56707c7c57f60be76210516dd4bb756b5c5f331676f761eaf987' + '00000000000000000000000000000006')
+    assert.strictEqual(root.data, 'b6e37356622cb2200b5086a628339f78a2de407223c5b4cb1c69c850dbeff1ae' + '00000000000000000000000000000006')
     assert.deepEqual(root.sum, new BN(6))
   })
 })

--- a/test/sum-tree/merkle-sum.js
+++ b/test/sum-tree/merkle-sum.js
@@ -15,8 +15,8 @@ describe('MerkleSumTree', function () {
       }
     ])
     const root = tree.root()
-    assert.strictEqual(root.data, '06b3dfaec148fb1bb2b066f10ec285e7c9bf402ab32aa78a5d38e34566810cd20000000000000001')
-    assert.strictEqual(root.sum, 1)
+    assert.strictEqual(root.data, '06b3dfaec148fb1bb2b066f10ec285e7c9bf402ab32aa78a5d38e34566810cd2' + '00000000000000000000000000000001')
+    assert.deepEqual(root.sum, new BN(1))
   })
   it('should generate an even tree correctly', function () {
     const tree = new MerkleSumTree([
@@ -30,8 +30,8 @@ describe('MerkleSumTree', function () {
       }
     ])
     const root = tree.root()
-    assert.strictEqual(root.data, '2b4f9a6acea717fe0fb4bd5b7c0aaf5f09a7926db5f7f11fcfc648b0880feb7e0000000000000003')
-    assert.strictEqual(root.sum, 3)
+    assert.strictEqual(root.data, '6bd541b4745da14453470d5f4d3599a706354199c742c35eb17e4738faa1c2a8' + '00000000000000000000000000000003')
+    assert.deepEqual(root.sum, new BN(3))
   })
   it('should generate an odd tree correctly', function () {
     const tree = new MerkleSumTree([
@@ -49,7 +49,7 @@ describe('MerkleSumTree', function () {
       }
     ])
     const root = tree.root()
-    assert.strictEqual(root.data, '7167636a248d9bb01310035817ec800400a43bfb598faea5aa9c162b23596f4b0000000000000006')
-    assert.strictEqual(root.sum, 6)
+    assert.strictEqual(root.data, '7c0beda9f03a56707c7c57f60be76210516dd4bb756b5c5f331676f761eaf987' + '00000000000000000000000000000006')
+    assert.deepEqual(root.sum, new BN(6))
   })
 })

--- a/test/sum-tree/plasma-sum-tree.js
+++ b/test/sum-tree/plasma-sum-tree.js
@@ -1,6 +1,17 @@
 /* global describe it */
 const assert = require('chai').assert
 const PlasmaMerkleSumTree = require('../../src/sum-tree/plasma-sum-tree')
+const TS = require('../../src/transaction-serialization')
+
+const tr1 = new TS.TR(['0x43aaDF3d5b44290385fe4193A1b13f15eF3A4FD5', '0xa12bcf1159aa01c739269391ae2d0be4037259f3', 0, 2, 3, 4])
+const tr2 = new TS.TR(['0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8', '0xa12bcf1159aa01c739269391ae2d0be4037259f4', 0, 6, 7, 5])
+const tr3 = new TS.TR(['0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8', '0xa12bcf1159aa01c739269391ae2d0be4037259f4', 1, 100, 108, 5])
+const sig = new TS.Sig([12345, 56789, 901234])
+
+const TX1 = new TS.Transaction([tr1], [sig])
+const TX2 = new TS.Transaction([tr2], [sig])
+const TX3 = new TS.Transaction([tr3], [sig])
+TX1.TRIndex = TX2.TRIndex = TX3.TRIndex = 0
 
 describe('PlasmaMerkleSumTree', function () {
   it('should return undefined for an empty tree', function () {
@@ -8,54 +19,22 @@ describe('PlasmaMerkleSumTree', function () {
     assert.strictEqual(tree.root(), undefined)
   })
   it('should generate a single-leaf tree correctly', function () {
-    const tree = new PlasmaMerkleSumTree([
-      {
-        data: 'tx1',
-        start: 0,
-        offset: 2
-      }
-    ])
+    const tree = new PlasmaMerkleSumTree([TX1])
     const root = tree.root()
-    assert.strictEqual(root.data, '5194ead3df889a15f3d33e47bcc128114dbb9dcd1147f2de8a8ffba6a815f248')
-    assert.strictEqual(root.sum, 2)
+    assert.strictEqual(root.data, '351a7a2ec4f370b6d2eea2199516c22f5582bf37b4a54173ca5abbca3d0a9c65' + '00000000000000000000000000000004')
+    assert.deepEqual(root.sum, new BN(4))
   })
   it('should generate an even tree correctly', function () {
-    const tree = new PlasmaMerkleSumTree([
-      {
-        data: 'tx1',
-        start: 0,
-        offset: 2
-      },
-      {
-        data: 'tx2',
-        start: 3,
-        offset: 2
-      }
-    ])
+    const tree = new PlasmaMerkleSumTree([TX1, TX2])
     const root = tree.root()
-    assert.strictEqual(root.data, '48c01c280e10f6722e4c2679c01f5290a70ee2c0f60b7850abab69f87eea0b7f0000000000000005')
-    assert.strictEqual(root.sum, 5)
+    assert.strictEqual(root.data, '80d452a7f386d2f79cabe5e4d73c2cc40d9708f2d3e30f78324076ba9c654c80' + '00000000000000000000000000000008')
+    assert.deepEqual(root.sum, new BN(8))
   })
-  it('should generate an odd tree correctly', function () {
-    const tree = new PlasmaMerkleSumTree([
-      {
-        data: 'tx1',
-        start: 0,
-        offset: 2
-      },
-      {
-        data: 'tx2',
-        start: 3,
-        offset: 2
-      },
-      {
-        data: 'tx3',
-        start: 6,
-        offset: 0
-      }
-    ])
+  it('should generate an odd tree w/ multiple types correctly', function () {
+    const tree = new PlasmaMerkleSumTree([TX1, TX2, TX3])
     const root = tree.root()
-    assert.strictEqual(root.data, '4743dab225c9e25efbc2c49e30e942da5259b3090b58b88586de5a3d238b3afc000000000000000B')
-    assert.strictEqual(root.sum, 11)
+    debugger
+    assert.strictEqual(root.data, '53b9d5ee2f4899976fc22da622f299f6a62bfa0cc2edd2da3ca608a776a315e4' + '0000000100000000000000000000006d')
+    // assert.deepEqual(root.sum, new BN(11))
   })
 })

--- a/test/sum-tree/plasma-sum-tree.js
+++ b/test/sum-tree/plasma-sum-tree.js
@@ -31,12 +31,10 @@ describe('PlasmaMerkleSumTree', function () {
   it('should generate an odd tree w/ multiple types correctly', function () {
     const tree = new PlasmaMerkleSumTree([TX1, TX2, TX3])
     const root = tree.root()
-    debugger
     assert.strictEqual(root.data, '26fa704d04daeef66fa9b5c89486813ad0697002cc6b82b52b8377b9fb7c28d4' + 'ffffffffffffffffffffffffffffffff')
   })
   it('should succeed in generating a tree of 100 ordered transactions', function () {
     const TXs = DT.genNSequentialTransactions(100)
     assert.doesNotThrow(function () {return new PlasmaMerkleSumTree(TXs)})
-    debugger
   })
 })

--- a/test/sum-tree/plasma-sum-tree.js
+++ b/test/sum-tree/plasma-sum-tree.js
@@ -33,7 +33,7 @@ describe('PlasmaMerkleSumTree', function () {
   it('should generate an odd tree w/ multiple types correctly', function () {
     const tree = new PlasmaMerkleSumTree([TX1, TX2, TX3])
     const root = tree.root()
-    debugger
+    tree.getBranch(2) // 2: 2 --> 0 -> 0, 3: 2 0 0, 4: 4, 2, 0, 5: 4 2 0 6: 6, 3.2 0
     assert.strictEqual(root.data, '53b9d5ee2f4899976fc22da622f299f6a62bfa0cc2edd2da3ca608a776a315e4' + '0000000100000000000000000000006d')
     // assert.deepEqual(root.sum, new BN(11))
   })

--- a/test/sum-tree/plasma-sum-tree.js
+++ b/test/sum-tree/plasma-sum-tree.js
@@ -2,12 +2,12 @@
 const assert = require('chai').assert
 const PlasmaMerkleSumTree = require('../../src/sum-tree/plasma-sum-tree')
 const TS = require('../../src/transaction-serialization')
+const DT = require('../dummy-tx-utils')
 
 const tr1 = new TS.TR(['0x43aaDF3d5b44290385fe4193A1b13f15eF3A4FD5', '0xa12bcf1159aa01c739269391ae2d0be4037259f3', 0, 2, 3, 4])
 const tr2 = new TS.TR(['0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8', '0xa12bcf1159aa01c739269391ae2d0be4037259f4', 0, 6, 7, 5])
 const tr3 = new TS.TR(['0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8', '0xa12bcf1159aa01c739269391ae2d0be4037259f4', 1, 100, 108, 5])
 const sig = new TS.Sig([12345, 56789, 901234])
-
 const TX1 = new TS.Transaction([tr1], [sig])
 const TX2 = new TS.Transaction([tr2], [sig])
 const TX3 = new TS.Transaction([tr3], [sig])
@@ -21,20 +21,25 @@ describe('PlasmaMerkleSumTree', function () {
   it('should generate a single-leaf tree correctly', function () {
     const tree = new PlasmaMerkleSumTree([TX1])
     const root = tree.root()
-    assert.strictEqual(root.data, '351a7a2ec4f370b6d2eea2199516c22f5582bf37b4a54173ca5abbca3d0a9c65' + '00000000000000000000000000000004')
-    assert.deepEqual(root.sum, new BN(4))
+    assert.strictEqual(root.data, '351a7a2ec4f370b6d2eea2199516c22f5582bf37b4a54173ca5abbca3d0a9c65' + 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
+    // assert.deepEqual(root.sum, new BN(4))
   })
   it('should generate an even tree correctly', function () {
     const tree = new PlasmaMerkleSumTree([TX1, TX2])
     const root = tree.root()
-    assert.strictEqual(root.data, '80d452a7f386d2f79cabe5e4d73c2cc40d9708f2d3e30f78324076ba9c654c80' + '00000000000000000000000000000008')
-    assert.deepEqual(root.sum, new BN(8))
+    assert.strictEqual(root.data, '80d452a7f386d2f79cabe5e4d73c2cc40d9708f2d3e30f78324076ba9c654c80' + 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
+    // assert.deepEqual(root.sum, new BN(8))
   })
   it('should generate an odd tree w/ multiple types correctly', function () {
     const tree = new PlasmaMerkleSumTree([TX1, TX2, TX3])
     const root = tree.root()
     tree.getBranch(2) // 2: 2 --> 0 -> 0, 3: 2 0 0, 4: 4, 2, 0, 5: 4 2 0 6: 6, 3.2 0
-    assert.strictEqual(root.data, '53b9d5ee2f4899976fc22da622f299f6a62bfa0cc2edd2da3ca608a776a315e4' + '0000000100000000000000000000006d')
+    assert.strictEqual(root.data, '53b9d5ee2f4899976fc22da622f299f6a62bfa0cc2edd2da3ca608a776a315e4' + 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
     // assert.deepEqual(root.sum, new BN(11))
+  })
+  it('should succeed in generating a tree of 100 ordered transactions', function () {
+    const TXs = DT.genNSequentialTransactions(100)
+    assert.doesNotThrow(function () {return new PlasmaMerkleSumTree(TXs)})
+    debugger
   })
 })

--- a/test/sum-tree/plasma-sum-tree.js
+++ b/test/sum-tree/plasma-sum-tree.js
@@ -21,21 +21,18 @@ describe('PlasmaMerkleSumTree', function () {
   it('should generate a single-leaf tree correctly', function () {
     const tree = new PlasmaMerkleSumTree([TX1])
     const root = tree.root()
-    assert.strictEqual(root.data, '351a7a2ec4f370b6d2eea2199516c22f5582bf37b4a54173ca5abbca3d0a9c65' + 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
-    // assert.deepEqual(root.sum, new BN(4))
+    assert.strictEqual(root.data, '351a7a2ec4f370b6d2eea2199516c22f5582bf37b4a54173ca5abbca3d0a9c65' + 'ffffffffffffffffffffffffffffffff')
   })
   it('should generate an even tree correctly', function () {
     const tree = new PlasmaMerkleSumTree([TX1, TX2])
     const root = tree.root()
-    assert.strictEqual(root.data, '80d452a7f386d2f79cabe5e4d73c2cc40d9708f2d3e30f78324076ba9c654c80' + 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
-    // assert.deepEqual(root.sum, new BN(8))
+    assert.strictEqual(root.data, 'beec6525a226cfc4e7494f14960aeaf4ce826f8998e675fbf58d07b89d0d2749' + 'ffffffffffffffffffffffffffffffff')
   })
   it('should generate an odd tree w/ multiple types correctly', function () {
     const tree = new PlasmaMerkleSumTree([TX1, TX2, TX3])
     const root = tree.root()
-    tree.getBranch(2) // 2: 2 --> 0 -> 0, 3: 2 0 0, 4: 4, 2, 0, 5: 4 2 0 6: 6, 3.2 0
-    assert.strictEqual(root.data, '53b9d5ee2f4899976fc22da622f299f6a62bfa0cc2edd2da3ca608a776a315e4' + 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
-    // assert.deepEqual(root.sum, new BN(11))
+    debugger
+    assert.strictEqual(root.data, '26fa704d04daeef66fa9b5c89486813ad0697002cc6b82b52b8377b9fb7c28d4' + 'ffffffffffffffffffffffffffffffff')
   })
   it('should succeed in generating a tree of 100 ordered transactions', function () {
     const TXs = DT.genNSequentialTransactions(100)

--- a/test/transaction-serialization/transaction-serialization.js
+++ b/test/transaction-serialization/transaction-serialization.js
@@ -1,0 +1,122 @@
+/* global describe it */
+const assert = require('chai').assert
+const tSerializer = require('../src/transaction-serialization')
+const Web3 = require('web3')
+const BN = Web3.utils.BN
+
+describe('TransactionSerialization', function () {
+  var tr1 = new tSerializer.SimpleSerializableElement(['0x43aaDF3d5b44290385fe4193A1b13f15eF3A4FD5', '0xa12bcf1159aa01c739269391ae2d0be4037259f3', 1, 2, 3, 4], tSerializer.schemas.TransferRecord)
+  var tr1ProperEncoding = [67, 170, 223, 61, 91, 68, 41, 3, 133, 254, 65, 147, 161, 177, 63, 21, 239, 58, 79, 213, 161, 43, 207, 17, 89, 170, 1, 199, 57, 38, 147, 145, 174, 45, 11, 228, 3, 114, 89, 243, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4]
+  var tr2 = new tSerializer.SimpleSerializableElement(['0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8', '0xa12bcf1159aa01c739269391ae2d0be4037259f4', 2, 3, 4, 5], tSerializer.schemas.TransferRecord)
+  var tr2ProperEncoding = [234, 103, 79, 221, 231, 20, 253, 151, 157, 227, 237, 240, 245, 106, 169, 113, 107, 137, 142, 200, 161, 43, 207, 17, 89, 170, 1, 199, 57, 38, 147, 145, 174, 45, 11, 228, 3, 114, 89, 244, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5]
+  var sig1 = new tSerializer.SimpleSerializableElement([12345, 56789, 901234], tSerializer.schemas.Signature)
+  var sig1ProperEncoding = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 213, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 192, 114]
+  var sig2 = new tSerializer.SimpleSerializableElement([12346, 56790, 901235], tSerializer.schemas.Signature)
+  var sig2ProperEncoding = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 214, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 192, 115]
+  var trList = new tSerializer.SimpleSerializableList([tr1, tr2, tr1], tSerializer.schemas.TransferRecord)
+  var sigList = new tSerializer.SimpleSerializableList([sig1, sig2, sig1], tSerializer.schemas.Signature)
+  var correctTRListEncoding = [3, 0, 0, 100].concat(tr1ProperEncoding).concat(tr2ProperEncoding).concat(tr1ProperEncoding)
+  var correctSigListEncoding = [3, 0, 0, 96].concat(sig1ProperEncoding).concat(sig2ProperEncoding).concat(sig1ProperEncoding)
+  let TX = new tSerializer.Transaction(trList, sigList)
+  let correctTXEncoding = correctTRListEncoding.concat(correctSigListEncoding)
+  it('should well-encode a TransferRecord', function () {
+    assert.deepEqual(tr1.encode(), tr1ProperEncoding)
+  })
+  it('should well-encode a Signature', function () {
+    assert.deepEqual(sig1.encode(), sig1ProperEncoding)
+  })
+  it('should well-encode a list of TransferRecords', function () {
+    assert.deepEqual(trList.encode(), correctTRListEncoding)
+  })
+  it('should well-encode a list of Signatures', function () {
+    assert.deepEqual(sigList.encode(), correctSigListEncoding)
+  })
+  it('should decode a random TransferRecords\' encoding to itself', function () {
+    var randomTR = genRandomTR()
+    var encoding = randomTR.encode()
+    var decoding = tSerializer.decodeElement(encoding, tSerializer.schemas.TransferRecord)
+    assert.deepEqual(randomTR, decoding)
+  })
+  it('should decode a random Signature\'s encoding to itself', function () {
+    var sig = genRandomSignature()
+    var encoding = sig.encode()
+    var decoding = tSerializer.decodeElement(encoding, tSerializer.schemas.Signature)
+    assert.deepEqual(sig, decoding)
+  })
+  it('should decode a random list of TRs to itself', function () {
+    var randomTR1 = genRandomTR()
+    var randomTR2 = genRandomTR()
+    var randomTR3 = genRandomTR()
+    var randomTR4 = genRandomTR()
+    var TRList = new tSerializer.SimpleSerializableList([randomTR1, randomTR2, randomTR3, randomTR4], tSerializer.schemas.TransferRecord)
+    var encoding = TRList.encode()
+    var decoding = tSerializer.decodeList(encoding, tSerializer.schemas.TransferRecord)
+    assert.deepEqual(TRList, decoding)
+  })
+  it('should decode a random list of Signatures to itself', function () {
+    var randomSig1 = genRandomSignature()
+    var randomSig2 = genRandomSignature()
+    var randomSig3 = genRandomSignature()
+    var randomSig4 = genRandomSignature()
+    var sigList = new tSerializer.SimpleSerializableList([randomSig1, randomSig2, randomSig3, randomSig4], tSerializer.schemas.Signature)
+    var encoding = sigList.encode()
+    var decoding = tSerializer.decodeList(encoding, tSerializer.schemas.Signature)
+    assert.deepEqual(sigList, decoding)
+  })
+  it('should well-encode a Transaction', function () {
+    var encoding = TX.encode()
+    assert.deepEqual(encoding, correctTXEncoding)
+  })
+  it('should decode a random Transaction to itself', function () {
+    var transactions = []
+    var signatures = []
+    for (var i = 0; i < 16; i++) { // let's do a full 16 sigs
+      transactions[i] = genRandomTR()
+      signatures[i] = genRandomSignature()
+    }
+    var TRList = new tSerializer.SimpleSerializableList(transactions, tSerializer.schemas.TransferRecord)
+    var sigList = new tSerializer.SimpleSerializableList(signatures, tSerializer.schemas.Signature)
+    var transaction = new tSerializer.Transaction(TRList, sigList)
+    var encoding = transaction.encode()
+    var decoding = tSerializer.decodeTransaction(encoding)
+    assert.deepEqual(transaction, decoding)
+  })
+})
+
+const genRandomSignature = function () {
+  var v = genRandomArrayOfNBytes(32)
+  var r = genRandomArrayOfNBytes(32)
+  var s = genRandomArrayOfNBytes(32)
+  return new tSerializer.SimpleSerializableElement([v, r, s], tSerializer.schemas.Signature)
+}
+
+const genRandomTR = function () {
+  var sender = genRandomAddress()
+  var recipient = genRandomAddress()
+  var type = genRandomArrayOfNBytes(4)
+  var coinID1 = genRandomArrayOfNBytes(12)
+  var coinID2 = genRandomArrayOfNBytes(12)
+  if (coinID1.lt(coinID2)) { // this makes sure offset after start
+    var start = coinID1
+    var offset = coinID2.sub(coinID1) // subtraction
+  } else {
+    var start = coinID2
+    var offset = coinID1.sub(coinID2)
+  }
+  var block = genRandomArrayOfNBytes(32)
+  var TR = new tSerializer.SimpleSerializableElement([sender, recipient, type, start, offset, block], tSerializer.schemas.TransferRecord)
+  return TR
+}
+
+const genRandomAddress = function () {
+  var addr = genRandomArrayOfNBytes(20)
+  return tSerializer.decodeAddress(addr)
+}
+
+const genRandomArrayOfNBytes = function (numBytes) { // returns an int not byte array
+  var arr = []
+  for (var i = 0; i < numBytes; i++) {
+    arr.push(Math.floor(Math.random() * (256)))
+  }
+  return new BN(arr)
+}

--- a/test/transaction-serialization/transaction-serialization.js
+++ b/test/transaction-serialization/transaction-serialization.js
@@ -18,7 +18,6 @@ describe('TransactionSerialization', function () {
   const correctTRListEncoding = [3, 0, 0, 100].concat(tr1ProperEncoding).concat(tr2ProperEncoding).concat(tr1ProperEncoding)
   const correctSigListEncoding = [3, 0, 0, 96].concat(sig1ProperEncoding).concat(sig2ProperEncoding).concat(sig1ProperEncoding)
   const TX = new TS.Transaction(trList, sigList)
-  debugger
   const correctTXEncoding = correctTRListEncoding.concat(correctSigListEncoding)
   it('should well-encode a TransferRecord', function () {
     assert.deepEqual(tr1.encode(), tr1ProperEncoding)

--- a/test/transaction-serialization/transaction-serialization.js
+++ b/test/transaction-serialization/transaction-serialization.js
@@ -100,7 +100,7 @@ const genRandomTR = function () {
     end = coinID1
   }
   const block = genRandomArrayOfNBytes(32)
-  const TR = new TS.SimpleSerializableElement([sender, recipient, type, start, end, block], TS.schemas.TransferRecord)
+  const TR = new TS.TR([sender, recipient, type, start, end, block])
   return TR
 }
 

--- a/test/transaction-serialization/transaction-serialization.js
+++ b/test/transaction-serialization/transaction-serialization.js
@@ -1,24 +1,25 @@
 /* global describe it */
 const assert = require('chai').assert
-const tSerializer = require('../src/transaction-serialization')
+const TS = require('../../src/transaction-serialization')
 const Web3 = require('web3')
 const BN = Web3.utils.BN
 
 describe('TransactionSerialization', function () {
-  var tr1 = new tSerializer.SimpleSerializableElement(['0x43aaDF3d5b44290385fe4193A1b13f15eF3A4FD5', '0xa12bcf1159aa01c739269391ae2d0be4037259f3', 1, 2, 3, 4], tSerializer.schemas.TransferRecord)
-  var tr1ProperEncoding = [67, 170, 223, 61, 91, 68, 41, 3, 133, 254, 65, 147, 161, 177, 63, 21, 239, 58, 79, 213, 161, 43, 207, 17, 89, 170, 1, 199, 57, 38, 147, 145, 174, 45, 11, 228, 3, 114, 89, 243, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4]
-  var tr2 = new tSerializer.SimpleSerializableElement(['0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8', '0xa12bcf1159aa01c739269391ae2d0be4037259f4', 2, 3, 4, 5], tSerializer.schemas.TransferRecord)
-  var tr2ProperEncoding = [234, 103, 79, 221, 231, 20, 253, 151, 157, 227, 237, 240, 245, 106, 169, 113, 107, 137, 142, 200, 161, 43, 207, 17, 89, 170, 1, 199, 57, 38, 147, 145, 174, 45, 11, 228, 3, 114, 89, 244, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5]
-  var sig1 = new tSerializer.SimpleSerializableElement([12345, 56789, 901234], tSerializer.schemas.Signature)
-  var sig1ProperEncoding = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 213, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 192, 114]
-  var sig2 = new tSerializer.SimpleSerializableElement([12346, 56790, 901235], tSerializer.schemas.Signature)
-  var sig2ProperEncoding = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 214, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 192, 115]
-  var trList = new tSerializer.SimpleSerializableList([tr1, tr2, tr1], tSerializer.schemas.TransferRecord)
-  var sigList = new tSerializer.SimpleSerializableList([sig1, sig2, sig1], tSerializer.schemas.Signature)
-  var correctTRListEncoding = [3, 0, 0, 100].concat(tr1ProperEncoding).concat(tr2ProperEncoding).concat(tr1ProperEncoding)
-  var correctSigListEncoding = [3, 0, 0, 96].concat(sig1ProperEncoding).concat(sig2ProperEncoding).concat(sig1ProperEncoding)
-  let TX = new tSerializer.Transaction(trList, sigList)
-  let correctTXEncoding = correctTRListEncoding.concat(correctSigListEncoding)
+  const tr1 = new TS.TR(['0x43aaDF3d5b44290385fe4193A1b13f15eF3A4FD5', '0xa12bcf1159aa01c739269391ae2d0be4037259f3', 1, 2, 3, 4])
+  const tr1ProperEncoding = [67, 170, 223, 61, 91, 68, 41, 3, 133, 254, 65, 147, 161, 177, 63, 21, 239, 58, 79, 213, 161, 43, 207, 17, 89, 170, 1, 199, 57, 38, 147, 145, 174, 45, 11, 228, 3, 114, 89, 243, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4]
+  const tr2 = new TS.TR(['0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8', '0xa12bcf1159aa01c739269391ae2d0be4037259f4', 2, 3, 4, 5])
+  const tr2ProperEncoding = [234, 103, 79, 221, 231, 20, 253, 151, 157, 227, 237, 240, 245, 106, 169, 113, 107, 137, 142, 200, 161, 43, 207, 17, 89, 170, 1, 199, 57, 38, 147, 145, 174, 45, 11, 228, 3, 114, 89, 244, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5]
+  const sig1 = new TS.Sig([12345, 56789, 901234])
+  const sig1ProperEncoding = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 213, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 192, 114]
+  const sig2 = new TS.Sig([12346, 56790, 901235])
+  const sig2ProperEncoding = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 221, 214, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 192, 115]
+  const trList = new TS.TRList([tr1, tr2, tr1])
+  const sigList = new TS.SigList([sig1, sig2, sig1])
+  const correctTRListEncoding = [3, 0, 0, 100].concat(tr1ProperEncoding).concat(tr2ProperEncoding).concat(tr1ProperEncoding)
+  const correctSigListEncoding = [3, 0, 0, 96].concat(sig1ProperEncoding).concat(sig2ProperEncoding).concat(sig1ProperEncoding)
+  const TX = new TS.Transaction(trList, sigList)
+  debugger
+  const correctTXEncoding = correctTRListEncoding.concat(correctSigListEncoding)
   it('should well-encode a TransferRecord', function () {
     assert.deepEqual(tr1.encode(), tr1ProperEncoding)
   })
@@ -32,90 +33,85 @@ describe('TransactionSerialization', function () {
     assert.deepEqual(sigList.encode(), correctSigListEncoding)
   })
   it('should decode a random TransferRecords\' encoding to itself', function () {
-    var randomTR = genRandomTR()
-    var encoding = randomTR.encode()
-    var decoding = tSerializer.decodeElement(encoding, tSerializer.schemas.TransferRecord)
+    const randomTR = genRandomTR()
+    const encoding = randomTR.encode()
+    const decoding = new TS.TR(encoding)
     assert.deepEqual(randomTR, decoding)
   })
   it('should decode a random Signature\'s encoding to itself', function () {
-    var sig = genRandomSignature()
-    var encoding = sig.encode()
-    var decoding = tSerializer.decodeElement(encoding, tSerializer.schemas.Signature)
+    const sig = genRandomSignature()
+    const encoding = sig.encode()
+    const decoding = new  TS.Sig(encoding)
     assert.deepEqual(sig, decoding)
   })
   it('should decode a random list of TRs to itself', function () {
-    var randomTR1 = genRandomTR()
-    var randomTR2 = genRandomTR()
-    var randomTR3 = genRandomTR()
-    var randomTR4 = genRandomTR()
-    var TRList = new tSerializer.SimpleSerializableList([randomTR1, randomTR2, randomTR3, randomTR4], tSerializer.schemas.TransferRecord)
-    var encoding = TRList.encode()
-    var decoding = tSerializer.decodeList(encoding, tSerializer.schemas.TransferRecord)
+    randomTRs = Array.from({ length: 4 }, () => { return genRandomTR() })
+    const TRList = new TS.TRList(randomTRs)
+    const encoding = TRList.encode()
+    const decoding = new TS.TRList(encoding)
     assert.deepEqual(TRList, decoding)
   })
   it('should decode a random list of Signatures to itself', function () {
-    var randomSig1 = genRandomSignature()
-    var randomSig2 = genRandomSignature()
-    var randomSig3 = genRandomSignature()
-    var randomSig4 = genRandomSignature()
-    var sigList = new tSerializer.SimpleSerializableList([randomSig1, randomSig2, randomSig3, randomSig4], tSerializer.schemas.Signature)
-    var encoding = sigList.encode()
-    var decoding = tSerializer.decodeList(encoding, tSerializer.schemas.Signature)
+    randomSigs = Array.from({ length: 4 }, () => { return genRandomSignature() })
+    const sigList = new TS.SigList(randomSigs)
+    const encoding = sigList.encode()
+    const decoding = new TS.SigList(encoding)
     assert.deepEqual(sigList, decoding)
   })
   it('should well-encode a Transaction', function () {
-    var encoding = TX.encode()
+    const encoding = TX.encode()
     assert.deepEqual(encoding, correctTXEncoding)
   })
   it('should decode a random Transaction to itself', function () {
-    var transactions = []
-    var signatures = []
-    for (var i = 0; i < 16; i++) { // let's do a full 16 sigs
+    let transactions = []
+    let signatures = []
+    for (let i = 0; i < 16; i++) { // let's do a full 16 sigs
       transactions[i] = genRandomTR()
       signatures[i] = genRandomSignature()
     }
-    var TRList = new tSerializer.SimpleSerializableList(transactions, tSerializer.schemas.TransferRecord)
-    var sigList = new tSerializer.SimpleSerializableList(signatures, tSerializer.schemas.Signature)
-    var transaction = new tSerializer.Transaction(TRList, sigList)
-    var encoding = transaction.encode()
-    var decoding = tSerializer.decodeTransaction(encoding)
+    const TRList = new TS.TRList(transactions)
+    const sigList = new TS.SigList(signatures)
+    const transaction = new TS.Transaction(TRList, sigList)
+    const encoding = transaction.encode()
+    const decoding = new TS.Transaction(encoding)
     assert.deepEqual(transaction, decoding)
   })
 })
 
 const genRandomSignature = function () {
-  var v = genRandomArrayOfNBytes(32)
-  var r = genRandomArrayOfNBytes(32)
-  var s = genRandomArrayOfNBytes(32)
-  return new tSerializer.SimpleSerializableElement([v, r, s], tSerializer.schemas.Signature)
+  const v = genRandomArrayOfNBytes(32)
+  const r = genRandomArrayOfNBytes(32)
+  const s = genRandomArrayOfNBytes(32)
+  return new TS.Sig([v, r, s])
 }
 
 const genRandomTR = function () {
-  var sender = genRandomAddress()
-  var recipient = genRandomAddress()
-  var type = genRandomArrayOfNBytes(4)
-  var coinID1 = genRandomArrayOfNBytes(12)
-  var coinID2 = genRandomArrayOfNBytes(12)
-  if (coinID1.lt(coinID2)) { // this makes sure offset after start
-    var start = coinID1
-    var offset = coinID2.sub(coinID1) // subtraction
+  const sender = genRandomAddress()
+  const recipient = genRandomAddress()
+  const type = genRandomArrayOfNBytes(4)
+  const coinID1 = genRandomArrayOfNBytes(12)
+  const coinID2 = genRandomArrayOfNBytes(12)
+  let start, end
+  if (coinID1.lt(coinID2)) {
+    start = coinID1
+    end = coinID2
   } else {
-    var start = coinID2
-    var offset = coinID1.sub(coinID2)
+    start = coinID2
+    end = coinID1
   }
-  var block = genRandomArrayOfNBytes(32)
-  var TR = new tSerializer.SimpleSerializableElement([sender, recipient, type, start, offset, block], tSerializer.schemas.TransferRecord)
+  const block = genRandomArrayOfNBytes(32)
+  const TR = new TS.SimpleSerializableElement([sender, recipient, type, start, end, block], TS.schemas.TransferRecord)
   return TR
 }
 
 const genRandomAddress = function () {
-  var addr = genRandomArrayOfNBytes(20)
-  return tSerializer.decodeAddress(addr)
+  const addr = genRandomArrayOfNBytes(20)
+  return TS.decodeAddress(addr)
 }
 
 const genRandomArrayOfNBytes = function (numBytes) { // returns an int not byte array
-  var arr = []
-  for (var i = 0; i < numBytes; i++) {
+  let arr = []
+  for (let i = 0; i < numBytes; i++) {
     arr.push(Math.floor(Math.random() * (256)))
   }
   return new BN(arr)


### PR DESCRIPTION
Cleans up code based on last code review

Adds new wrapper classes TR, Sig, TRList, and SigList for more intelligent element creation.  Now, to create a new transfer, we can use any of the following formats:

```new TR([sender, recipient, type, ...])```
```new TR({sender: sender, recipient: recipient, type: type,...})```
```new TR(encoding)```

And the List classes can accept similarly intelligent constructors in a nested fashion, so the following are equivalent:
```new TRList([new TR([a,b,c,...]), new TR([d,e,f...])])``` and
```new TRList([[a,b,c...],[d,e,f...]])```